### PR TITLE
added list-type 'L' support (fixed)

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -499,6 +499,17 @@ function DynamoDB() {
 		}
 
 		if (typeof $value == 'object') {
+
+			if(Array.isArray($value) ) {
+				var to_ret = {'L': [] }
+				for (var i in $value) {
+					if ($value.hasOwnProperty(i)) {
+						to_ret.L[i] = this.anormalizeValue($value[i] )
+					}
+				}
+				return to_ret
+			}
+
 			var to_ret = {'M': {} }
 			for (var i in $value) {
 				if ($value.hasOwnProperty(i)) {
@@ -519,6 +530,9 @@ function DynamoDB() {
 
 		if (typeof $value == 'string')
 			return 'S'
+
+		if (Array.isArray($value))
+			return 'L'
 
 		if ($value === null) {
 			return 'NULL'
@@ -548,6 +562,17 @@ function DynamoDB() {
 					
 				if ($item[key].hasOwnProperty('NULL'))
 					normal[key] = null
+
+				if ($item[key].hasOwnProperty('L')){
+					normal[key] = []
+					for (var i in $item[key]['L'] ) {
+						if ($item[key]['L'].hasOwnProperty(i)) {
+							normal[key][i] = this.normalizeItem({
+									key: $item[key]['L'][i]
+							}).key
+						}
+					}
+				}
 
 				if ($item[key].hasOwnProperty('M')) {
 					normal[key] = {}


### PR DESCRIPTION
I added list type ('L') support for my use, using the copy of code for object ('M') type handling.

I thought tested it on my test application on both get and put but actually I only had get part right.
This time I made sure it works both ways (normalize & anormalize)

If there's any problem let me know, i'll look into it.