### PR TITLE
Allow instance of DynamoDB client to be passed in

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -15,11 +15,16 @@ module.exports = function config ( $config ) {
 	this.ALL_PROJECTED_ATTRIBUTES = 2
 	this.COUNT = 3	
 
-	if ($config)
-		AWS.config.update($config)
-
-	this.client = $db = new AWS.DynamoDB()
-
+	if ($config instanceof AWS.DynamoDB) {
+		this.client = $db = $config
+		$config = null
+	} else {
+		if ($config)
+			AWS.config.update($config)
+		
+		this.client = $db = new AWS.DynamoDB()		
+	}
+	
 	this.table = function( $tableName ) {
 		var $ddb = new DynamoDB()
 		


### PR DESCRIPTION
Not sure if you'd be open to this kind of PR, but there are times when I want to manage some aspects of DynamoDB client myself (like config / features not supported by aws-dynamodb), but still use aws-dynamodb for other things (like inserts and querying tables).

This allows an instance of AWS.DynamoDB to be passed in to aws-dynamodb instead of a config.

If you like this, I will also update the gh-pages to document this feature.