### PR TITLE
Missing "$" in $thisQuery var name for .get() when specifying attributes

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -436,7 +436,7 @@ function DynamoDB() {
 		}
 
 		if (this.AttributesToGet.length)
-			thisQuery['AttributesToGet'] = this.AttributesToGet;
+			$thisQuery['AttributesToGet'] = this.AttributesToGet;
 
 		$db.getItem( $thisQuery, function(err,data) {
 			if (err) {


### PR DESCRIPTION
Line 439: looks like an easy typo to have made.

Thanks for the module.