### PR TITLE
Allow for int or decimal values to be parsed from db objects

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -778,7 +778,7 @@ function DynamoDB() {
 					normal[key] = $item[key]['S']
 				
 				if ($item[key].hasOwnProperty('N'))
-					normal[key] = parseInt($item[key]['N'])
+					normal[key] = +($item[key]['N'])
 					
 				if ($item[key].hasOwnProperty('BOOL'))
 					normal[key] = $item[key]['BOOL']

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -436,7 +436,7 @@ function DynamoDB() {
 		}
 
 		if (this.AttributesToGet.length)
-			thisQuery['AttributesToGet'] = this.AttributesToGet;
+			$thisQuery['AttributesToGet'] = this.AttributesToGet;
 
 		$db.getItem( $thisQuery, function(err,data) {
 			if (err) {


### PR DESCRIPTION
**parseInt()** will only translate the *integer* portion of a numeric value, not a *decimal*.  This allows for parsing of any numeric value from the stored string.