### PR TITLE
Allow the object passage containing actions for each attribute.

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -302,15 +302,22 @@
 				}
 
 			var $to_update = {}
+			var $a
 			for (var $k in $attrz) {
 				if ($attrz.hasOwnProperty($k)) {
+					if ( typeof $action === 'object' ) {
+						$a = $action[$k];
+					} else {
+						$a = $action;
+					}
+
 					if ($attrz[$k] === undefined ) {
 						$to_update[$k] = {
-							Action: $action ? $action : 'DELETE',
+							Action: $a ? $a : 'DELETE',
 						}
 					} else {
 						$to_update[$k] = {
-							Action: $action ? $action : 'PUT',
+							Action: $a ? $a : 'PUT',
 							Value: util.anormalizeValue($attrz[$k])
 						}
 					}
@@ -352,15 +359,22 @@
 				delete $attrz[data.Table.KeySchema[i].AttributeName]
 			}
 			var $to_update = {}
+			var $a
 			for (var $k in $attrz) {
 				if ($attrz.hasOwnProperty($k)) {
+					if ( typeof $action === 'object' ) {
+						$a = $action[$k];
+					} else {
+						$a = $action;
+					}
+
 					if ($attrz[$k] === undefined ) {
 						$to_update[$k] = {
-							Action: $action ? $action : 'DELETE',
+							Action: $a ? $a : 'DELETE',
 						}
 					} else {
 						$to_update[$k] = {
-							Action: $action ? $action : 'PUT',
+							Action: $a ? $a : 'PUT',
 							Value: util.anormalizeValue($attrz[$k])
 						}
 					}


### PR DESCRIPTION
In my case I have a list and i needed append this list in "insert_or_update" and if changing for the other method the method not attended my necessity, because I had atributes null.

```
/* First insert_or_update */
DynamoDB
    .table(TABLE)
    .insert_or_update({
      hash: 'USER:123',
      phones: ['9988999'],
      status: null 
    }, function (err, data) {
      if (err) throw (err);
      console.log(data);
    });
```

```
/* Second insert_or_update */
DynamoDB
    .table(TABLE)
    .insert_or_update({
      hash: 'USER:123',
      phones: ['99114999'],
      status: null 
    }, function (err, data) {
      if (err) throw (err);
      console.log(data);
    }, {
      phones: 'ADD'
    });
```