### PR TITLE
Adding ReturnValues for updateItem calls

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -116,7 +116,7 @@
 				$this.ConsumedCapacity = data.ConsumedCapacity
 
 			if ((data || {}).hasOwnProperty('Attributes') )
-				$this.Attributes = util.normalizeItem(data.Attributes)
+				data.Attributes = util.normalizeItem(data.Attributes)
 
 			callback.apply( $this, [ err, data ] )
 		})

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -98,6 +98,7 @@
 		this.ExclusiveStartKey = null
 		this.ConsistentRead = false
 		this.returnConsumedCapacity = 'INDEXES' // TOTAL | INDEXES | NONE
+		this.returnValues = 'ALL_NEW' // ALL_OLD | UPDATED_OLD | ALL_NEW | UPDATED_NEW | NONE
 		this.ConsumedCapacity = null
 	}
 
@@ -113,6 +114,9 @@
 
 			if ((data || {}).hasOwnProperty('ConsumedCapacity') )
 				$this.ConsumedCapacity = data.ConsumedCapacity
+
+			if ((data || {}).hasOwnProperty('Attributes') )
+				$this.Attributes = util.normalizedItem(data.Attributes)
 
 			callback.apply( $this, [ err, data ] )
 		})
@@ -354,7 +358,8 @@
 				Key: this.whereKey,
 				AttributeUpdates : $to_update,
 				Expected: $expected,
-				ReturnConsumedCapacity: this.returnConsumedCapacity
+				ReturnConsumedCapacity: this.returnConsumedCapacity,
+				ReturnValues: this.returnValues
 			}
 
 			this.routeCall('updateItem', $thisQuery , function(err,data) {
@@ -405,7 +410,8 @@
 				TableName: this.tableName,
 				Key: this.whereKey,
 				AttributeUpdates : $to_update,
-				ReturnConsumedCapacity: this.returnConsumedCapacity
+				ReturnConsumedCapacity: this.returnConsumedCapacity,
+				ReturnValues: this.returnValues
 			}
 			this.routeCall('updateItem', $thisQuery , function(err,data) {
 				if (err)
@@ -459,7 +465,8 @@
 				TableName: this.tableName,
 				Key: this.whereKey,
 				AttributeUpdates : $to_delete,
-				ReturnConsumedCapacity: this.returnConsumedCapacity
+				ReturnConsumedCapacity: this.returnConsumedCapacity,
+				ReturnValues: this.returnValues
 			}
 			this.routeCall('updateItem', $thisQuery , function(err,data) {
 				if (err)

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -116,7 +116,7 @@
 				$this.ConsumedCapacity = data.ConsumedCapacity
 
 			if ((data || {}).hasOwnProperty('Attributes') )
-				$this.Attributes = util.normalizedItem(data.Attributes)
+				$this.Attributes = util.normalizeItem(data.Attributes)
 
 			callback.apply( $this, [ err, data ] )
 		})


### PR DESCRIPTION
Hi,

I had an issue where a lambda function I was writing was passing the event object for persistence by the insert_or_update function. If my event didn't have a hash key property set, I created one (insert) or I left the object as it was passed in. My callback then passed back event. Since insert_or_replace is deleting the hash key properties, this didn't work as expected. Rather than complicate things by cloning objects, I thought it useful to add to the aws-dynamodb library and pass back ReturnValues (normalized as well which is even more useful) which the callback can use.

Hope you find this useful.

Mark